### PR TITLE
Add support for the Zephyr project.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ directory with a specific structure:
 
 It will then generate the other two variables upon calling the query
 command. For now, three projects are hard-coded into the shell script
-(to handle version grouping and display): Linux, U-Boot and Busybox.
+(to handle version grouping and display): Linux, U-Boot, Busybox and
+Zephyr.
 
 Here is an example configuration for Apache:
 

--- a/script.sh
+++ b/script.sh
@@ -86,6 +86,12 @@ case $cmd in
                 tac |
                 sed -r 's/^([0-9])\.([0-9]*)(.*)$/v\1 \1.\2 \1.\2\3/'
               ;;
+              zephyr)
+                echo "$tags" |
+                grep -v '^zephyr-v' |
+                tac |
+                sed -r 's/^(v[0-9])\.([0-9]*)(.*)$/\1 \1.\2 \1.\2\3/'
+              ;;
               *)
                 echo "$tags" |
                 tac |
@@ -93,12 +99,27 @@ case $cmd in
               ;;
             esac
         else
-            echo "$tags"
+            case $project in
+              zephyr)
+                echo "$tags" |
+                grep -v '^zephyr-v'
+              ;;
+              *)
+                echo "$tags"
+              ;;
+            esac
         fi
         ;;
 
     get-latest)
-        git tag | version_dir | grep -v '\-rc' | sort -V | tail -n 1
+        case $project in
+          zephyr)
+            git tag | grep -v '^zephyr-v' | version_dir | grep -v '\-rc' | sort -V | tail -n 1
+          ;;
+          *)
+            git tag | version_dir | grep -v '\-rc' | sort -V | tail -n 1
+          ;;
+        esac
         ;;
 
     get-type)


### PR DESCRIPTION
This PR adds support to Elixir for the Zephyr Project, a Linux Foundation Project (see https://www.zephyrproject.org for more information). The Zephyr Project has much in common with Linux and could benefit from having its source code indexed by Elixir in the same manner as Linux, Busybox and Das U-Boot.

The `zephyr-vx.y.z` tags are technically redundant and filtered out as discussed in zephyrproject-rtos/zephyr#1420.