### PR TITLE
Fall back to subprocess.check_output when subprocess.run is not available

### DIFF
--- a/lib.py
+++ b/lib.py
@@ -22,8 +22,13 @@ import subprocess
 
 def script (*args):
     args = ('./script.sh',) + args
-    p = subprocess.run (args, stdout=subprocess.PIPE)
-    p = p.stdout
+    # subprocess.run was introduced in Python 3.5
+    # fall back to subprocess.check_output if it's not available
+    if hasattr(subprocess, 'run'):
+        p = subprocess.run (args, stdout=subprocess.PIPE)
+        p = p.stdout
+    else:
+        p = subprocess.check_output(args)
     return p
 
 def scriptLines (*args):


### PR DESCRIPTION
On machines with Python < 3.5, subprocess.run is not available. In this
case, subprocess.check_output serves the same purpose [1].

This allows Elixir to run on older systems, such as Ubuntu 14.04 which
comes with Python 3.4.

[1] https://docs.python.org/3.5/library/subprocess.html#subprocess.check_output

Signed-off-by: Chen-Yu Tsai <wens@csie.org>