### PR TITLE
Add basic support for C++ files

### DIFF
--- a/query.py
+++ b/query.py
@@ -63,7 +63,7 @@ def query (cmd, *args):
     elif cmd == 'file':
         version = args[0]
         path = args[1]
-        ext = path[-2:]
+        ext = os.path.splitext(path)[1]
 
         if ext == '.c' or ext == '.h':
             tokens = scriptLines ('tokenize-file', version, path)

--- a/query.py
+++ b/query.py
@@ -65,7 +65,7 @@ def query (cmd, *args):
         path = args[1]
         ext = os.path.splitext(path)[1]
 
-        if ext == '.c' or ext == '.h':
+        if ext in ['.c', '.cc', '.cpp', '.h']:
             tokens = scriptLines ('tokenize-file', version, path)
             even = True
             for tok in tokens:

--- a/update.py
+++ b/update.py
@@ -75,7 +75,7 @@ def updateDefinitions (blobs):
         filename = db.file.get (blob)
 
         ext = os.path.splitext(filename)[1]
-        if not (ext == '.c' or ext == '.h'): continue
+        if ext not in ['.c', '.cc', '.cpp', '.h']: continue
 
         lines = scriptLines ('parse-defs', hash, filename)
         for l in lines:
@@ -98,7 +98,7 @@ def updateReferences (blobs):
         filename = db.file.get (blob)
 
         ext = os.path.splitext(filename)[1]
-        if not (ext == '.c' or ext == '.h'): continue
+        if ext not in ['.c', '.cc', '.cpp', '.h']: continue
 
         tokens = scriptLines ('tokenize-file', '-b', hash)
         even = True

--- a/update.py
+++ b/update.py
@@ -74,7 +74,7 @@ def updateDefinitions (blobs):
         hash = db.hash.get (blob)
         filename = db.file.get (blob)
 
-        ext = filename[-2:]
+        ext = os.path.splitext(filename)[1]
         if not (ext == '.c' or ext == '.h'): continue
 
         lines = scriptLines ('parse-defs', hash, filename)
@@ -97,7 +97,7 @@ def updateReferences (blobs):
         hash = db.hash.get (blob)
         filename = db.file.get (blob)
 
-        ext = filename[-2:]
+        ext = os.path.splitext(filename)[1]
         if not (ext == '.c' or ext == '.h'): continue
 
         tokens = scriptLines ('tokenize-file', '-b', hash)


### PR DESCRIPTION
Include C++ files when indexing and tokenizing files.

Unfortunately due to how C++ utilizes namespaces and classes, depending
on your code base, this currently introduces a large amount of false positives
for unqualified identifiers that look the same.